### PR TITLE
FNVLODGen > Clarification on argument sections

### DIFF
--- a/lodhigh.html
+++ b/lodhigh.html
@@ -137,7 +137,7 @@ SOFTWARE.
             <ul class="specialinstructions">
                 <li>Click the <img src="./img/mo2executabes.png" alt="MO2 Executables Button"> button on the top bar of MO2</li>
                 <li>Select the <strong>FNVLODGen</strong> option</li>
-                <li>In the <strong>Arguments</strong> box, add <strong>-o:"FNVLODGen path/Output"</strong></li>
+                <li>In the <strong>Arguments</strong> box, add <strong>-o:"FNVLODGen path/Output"</strong> and separate from the -fnv argument with a space</li>
                     <ul>
                         <li>Make sure to change the path to a file path that actually exists on your computer, for example <strong>-o:"C:\Games\Fallout New Vegas Modding\FNVLODGen\Output"</strong></li>
                         <li>Makes sure you keep the <strong>-fnv</strong> argument as well</li>


### PR DESCRIPTION
On [Visuals High: LOD](https://vivanewvegas.github.io/lodhigh.html) it might not be super clear for those who don't mod that you need to separate arguments with a space.
I was able to find this solution on the Discord, but could save some time for other users, and it's just a minor change to the text.