### PR TITLE
Fix #9

### DIFF
--- a/hightexmodels.html
+++ b/hightexmodels.html
@@ -250,6 +250,10 @@ SOFTWARE.
                         <ul>
                             <li>Hides the water effect textures because they are broken, causing water to look very pixelated</li>
                         </ul>
+                    <li><strong>textures/sky/nv_sunglare.dds</strong></li>
+                        <ul>
+                            <li>Seems to stack with Nevada Skies sunglare.</li>
+                        </ul>
                 </ul>
             <p class="moddesc"> - Remakes every last visual effect texture</p>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/64214?tab=files" target="_blank">Super Mutants HD</a></h2>


### PR DESCRIPTION
Effect teXtures Enhanced (EXE)'s sunglare texture seems to stack with
Nevada Skies (NS) sunglare texture. Therefor, it is recommended to hide
EXE's sunglare to have a less obnoxious sunglare.

Co-authored-by: Teacyn <misnerjarrod5@gmail.com>