### PR TITLE
Small style change for download link

### DIFF
--- a/core-optional.html
+++ b/core-optional.html
@@ -86,7 +86,7 @@ SOFTWARE.
                 <h2 class="modhead"><a class="modlink" href="https://geckwiki.com/index.php?title=Garden_of_Eden_Creation_Kit" target="_blank">GECK</a></h2>
                     <p class="specialinstall"><strong>Installation Instructions:</strong></p>
                         <ul class="specialinstructions">
-                            <li>Click the <strong>Download the Garden of Eden Creation Kit for Fallout New Vegas <u>here</u></strong> link</li>
+                            <li>Click the <strong>Download the Garden of Eden Creation Kit for Fallout New Vegas <i>here</i></strong> link</li>
                             <li>Extract the contents of the archive to the <strong>Root</strong> folder</li>
                         </ul>
                     <p class="moddesc"> - Tool that allows you to create/edit any data from the game</p>


### PR DESCRIPTION
Some readers confuse the description for a click-able link.
By changing the style from underline to italic it should be clearer that the description isn't to be clicked on.