### PR TITLE
Internal links

### DIFF
--- a/content-equip.html
+++ b/content-equip.html
@@ -73,7 +73,7 @@ SOFTWARE.
                 <li>Right-click in the left pane of MO2 and select <strong>All Mods -> Create Separator</strong></li>
                 <li>Input <strong>Equipment</strong> into the pop-up and select <strong>OK</strong></li>
             </ul>
-        <h2 class="installingfnv">Weapons:</h2>
+        <a href="#weapons"><h2 class="installingfnv" id="weapons">Weapons:</h2></a>
         <h2 class="modhead">IMPORTANT NOTE:</h2>
             <p class="moddesc">The guide will provide merged plugins for the following weapons/armors that balance them and give them proper integration. You still must install <i>all</i> of the following mods and keep them active in MO2 (with the original plugins hidden) in order for the merged plugins to work, as the original assets are still needed</p>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/57253" target="_blank">PKM</a></h2>
@@ -146,7 +146,7 @@ SOFTWARE.
             <p class="moddesc">
                 - You need ALL the previous weapon mods installed, or else you will get invisible weapons.
             </p>
-    <h2 class="installingfnv">Armor:</h2>
+    <a href="#armor"><h2 class="installingfnv" id="armor">Armor:</h2>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/44476" target="_blank">Spice of Life</a></h2>
             <p class="specialinstall"><strong>Installation instructions:</strong></p>
                 <ul class="specialinstructions">

--- a/content.html
+++ b/content.html
@@ -66,19 +66,19 @@ SOFTWARE.
         <hr>
     </div>
     <div>
-        <h2 class="corereq">Requirements:</h2>
+        <a href="#requirements"><h2 class="corereq" id =requirements">Requirements:</h2></a>
             <ul class="corereqlist">
                <li>A working installation of the <strong>Core</strong> module</li>
                <li>2 gigabytes of free disk space</li>
             </ul>
         <hr>
-        <h2 class="corereq">The Goal of the Content Module:</h2>
+        <a href="#goal"><h2 class="corereq" id="goal">The Goal of the Content Module:</h2></a>
             <p class="moddesc">
                 The goal of this module is to add lore friendly and balanced new content to spice up the game for veteran players, and more great vanilla-feeling content to the game for beginner players.
                 All mods are carefully picked out and tweaked to be as high quality and fun as possible. 
             </p>
         <hr>
-        <h2 class="corespecs">My System Specs:</h2>
+        <a href="#specs"><h2 class="corespecs" id="specs">My System Specs:</h2></a>
             <ul class="corereqlist">
                 <li>The <strong>Content</strong> module will make the game run slightly worse on low-end hardware due to added NPCs/scripts. Most modern PCs will not see much FPS loss at all, my specs are here for reference</li>
             </ul>

--- a/core-avoid.html
+++ b/core-avoid.html
@@ -70,7 +70,7 @@ SOFTWARE.
     </div>    
     <div>
         <p class="moddesc">You may be wondering why some mods/tools aren't in the guide, or are looking to add your own mods. If so, please reference this list:</p>
-        <h2 class="installingfnv">Mod Managers to Avoid:</h2>
+        <a href="#mod_managers_to_avoid"><h2 class="installingfnv" id="mod_managers_to_avoid">Mod Managers to Avoid:</h2></a>
         <p class="moddesc"><strong>Vortex:</strong> Lacks many essential features (such as manual load order control) and has some critical bugs. 
             Uses Symlinks instead of a UVFS like MO2 (see <a class="modsublink" href="https://github.com/TanninOne/usvfs/blob/master/README.md" target="_blank">here</a> for a comparison). Probably the second best mod manager, but there is literally no reason to use it over MO2 <br> <br>
 
@@ -80,7 +80,7 @@ SOFTWARE.
 
                            <strong>MO1:</strong> MO2, even though designed for 64bit games, works perfect for New Vegas
         </p>
-        <h2 class="installingfnv">Other Tools to Avoid:</h2>
+        <a href="#tools_to_avoid"><h2 class="installingfnv" id="tools_to_avoid">Other Tools to Avoid:</h2></a>
         <p class="moddesc">
             <strong>LOOT and automated conflict resolution (kind of):</strong> Automated tools will never be able to manage a large load order well on their own. For small (sub-50 mod) load orders, they will suffice.
             However, if you use any large amount of mods, the only way to ensure perfection is looking at conflicts in xEdit, sorting your load order to minimize conflicts, and then creating your own conflict resolution to cover what can't be fixed by load order adjustment. <br> <br>
@@ -93,7 +93,7 @@ SOFTWARE.
 
             <strong>BethINI/Configator:</strong> Most INI changes are placebo at best, dangerous at worst. You really won't need any other INI tweaks than the ones in the guide
         </p>
-        <h2 class="installingfnv">Utilities to Avoid:</h2>
+        <a href="#utilities_to_avoid"><h2 class="installingfnv" id="utilities_to_avoid">Utilities to Avoid:</h2></a>
             <p class="moddesc"><strong>NVSR:</strong> NVTF is a modern recreation of NVSR that works perfectly and has many more features, there is no reason to use NVSR over NVTF. The following settings are broken in NVSR:</p>
                     <ul class="specialinstructions">
                         <li><strong>bManageFPS:</strong> Doesn't straight up limit FPS, but maintains a minimum FPS, so it starts to disable LOD and other things to maintain that FPS (paraphrased from RoyBatty)</li>
@@ -109,10 +109,10 @@ SOFTWARE.
             <p class="moddesc"><strong>Performance of the Gods (or pretty much all mods with "Performance" in the title):</strong> Performance gain is placebo, disabling random clutter items with less than 5 polygons isn't going to do anything. 
                 Potentially dangerous if they use Mark for Delete instead of Initially Disabled
             </p>
-        <h2 class="installingfnv">Bug Fixes to Avoid:</h2>
+        <a href="#fixes_to_avoid"><h2 class="installingfnv" id="fixes_to_avoid">Bug Fixes to Avoid:</h2></a>
             <p class="moddesc"><strong>Mission Mojave:</strong> Breaks more than it fixes, will cause crashes, very outdated, far inferior to YUP</p>
             <p class="moddesc"><strong>Pretty much any old single bug fix mod, such as Reload Speed Game Start Fix:</strong> - In most cases, these fixes are included in YUP/UPNVSE/lStewieAl's Tweaks, and if they are not its most likely because of poor implementation on the mod's end or the bug the mod fixes not actually being considered a bug</p>
-        <h2 class="installingfnv">HUD Mods to Avoid:</h2>
+        <a href="#hud_to_avoid"><h2 class="installingfnv" id="hud_to_avoid">HUD Mods to Avoid:</h2></a>
             <p class="moddesc"><strong>MTUI:</strong> Old and obsolete, <a class="modsublink" href="https://imgur.com/a/PFSVi" target="_blank">and has a lot of problems</a></p>
             <p class="moddesc"><strong>Unified HUD Project - uHUD:</strong> Abandoned by the author in favor of UIO</p>
             <p class="moddesc"><strong>No Dialogue Tags (NVSE) (DLC - TTW - Mods):</strong> Hides all text in brackets, including Christine's dialogue in Dead Money. Use the updated, ESPless implementation in lStewieAl's Tweaks instead</p>

--- a/core-initweaks.html
+++ b/core-initweaks.html
@@ -70,7 +70,7 @@ SOFTWARE.
         <hr>
     </div> 
     <div>
-        <h2 class="installingfnv">Tweaking FalloutCustom.ini:</h2>
+        <a href="#tweaking_falloutcustom"><h2 class="installingfnv" id="tweaking_falloutcustom">Tweaking FalloutCustom.ini:</h2></a>
             <ul class="specialinstructions">
                 <li>Make sure the <strong>Viva New Vegas - Core</strong> profile is active</li>
                 <li>Click the <img class="mo2setting" src="./img/mo2ini.png" alt="mo2 executables"> button on the top bar of MO2 and select <strong>INI Editor</strong></li>
@@ -189,7 +189,7 @@ SOFTWARE.
                         </div>
                 </div>
                 
-        <h2 class="installingfnv">INI Settings to not change:</h2>
+        <a href="#do_not_change"><h2 class="installingfnv" id="do_not_change">INI Settings to not change:</h2></a>
             <p class="moddesc">
                 <strong>uGridsToLoad=5:</strong> Changes the amount of cells loaded at once. When changed, it can cause scripts to run when they aren't supposed to, will ruin performance, and will break your game if changed on an existing save <br> <br>
                 <strong>INumHavokThreads=1:</strong> Any changes to it are placebo in regards to performance, can cause instability if set over 2 <br> <br>

--- a/core-installation.html
+++ b/core-installation.html
@@ -68,7 +68,7 @@ SOFTWARE.
         <hr>
         <p class="installingfnvdesc">These steps will take you over how to do a fresh installation of Fallout New Vegas, which is required for this guide</p>
         <hr>
-        <h2 class="installingfnv">Installation Parameters:</h2>      
+        <a href="#parameters"><h2 class="installingfnv" id="parameters">Installation Parameters:</h2></a>      
         <p class="moddesc">
           - Fallout New Vegas and all modding tools must be installed outside all default Windows folders (<strong>Program Files</strong>, <strong>Program Files (x86)</strong>, <strong>Desktop</strong>, and <strong>Documents</strong> for example)
               <ul class="specialinstructions">
@@ -92,7 +92,7 @@ SOFTWARE.
                 </ul>
             </p>  
         <hr>    
-        <h2 class="installingfnv">Common Terminology:</h2>
+        <a href="#terminology"><h2 class="installingfnv" id="terminology">Common Terminology:</h2></a>
           <ul class="specialinstructions">
             <li><strong>Root</strong> folder: Where Fallout New Vegas is installed</li>
               <ul>
@@ -107,7 +107,7 @@ SOFTWARE.
             <li> MO2: <strong>Mod Organizer 2</strong> (will be installed shortly)<br></li>
           </ul>
           <hr>
-            <h2 class="installingfnv">Installing Prerequisites:</h2>
+            <a href="#prerequisites"><h2 class="installingfnv" id="prerequisites">Installing Prerequisites:</h2></a>
               <h2 class="modhead"><a class="modlink" href="http://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe" target="_blank">Microsoft VC++ 2013</a></h2>
               <p class="specialinstall"><strong>Installation Instructions:</strong></p>
                   <ul class="specialinstructions">
@@ -147,7 +147,7 @@ SOFTWARE.
                     <li>If it says your drivers are outdated, let it update your drivers to the latest version</li>
                   </ul>
                 <hr>
-        <h2 class="installingfnv">Installing Fallout New Vegas:</h2>      
+        <a href="#installing_fnv"><h2 class="installingfnv" id="installing_fnv">Installing Fallout New Vegas:</h2></a>      
           <div class="installcontainer">
             <button class="accordioninstall">I do not have Fallout New Vegas installed</button>
               <div class="panelinstall">
@@ -203,7 +203,7 @@ SOFTWARE.
               </div>
           </div>
         <hr>
-        <h2 class="installingfnv">Setting up your Modding Folder:</h2>
+        <a href="#modding_folder"><h2 class="installingfnv" id="modding_folder">Setting up your Modding Folder:</h2></a>
           <p class="modfolderdesc">
             Your modding folder will act as the main directory for all the tools you install, as well as any backups/screenshots/etc. you may want to keep. This folder will be referred to as the <strong>Modding folder</strong> from now on
               <ul class="modfolderlist">
@@ -217,7 +217,7 @@ SOFTWARE.
             </p>    
           </p>
           <hr>
-        <h2 class="installingfnv">Disabling Anti-Virus:</h2>
+        <a href="#disabling_av"><h2 class="installingfnv" id="disabling_av">Disabling Anti-Virus:</h2></a>
           <p class="overlaydesc">
             Any anti-virus you have, including Windows Defender, needs to have <a class="modsublink" href="https://support.microsoft.com/en-us/help/4028485/windows-10-add-an-exclusion-to-windows-security" target="_blank">file exceptions made</a> for your <strong>Root</strong> folder and <strong>Modding folder</strong>.
             If Windows will not let you add an exclusion via the UI per those instructions, you can use <a class="modsublink" href="https://answers.microsoft.com/en-us/protect/forum/all/windows-antivirus-will-not-allow-me-to-to-add/f4fd924b-9c89-4dab-9e45-2fc64f43ff88" target="_blank">this</a> method of using Windows Powershell instead.
@@ -225,7 +225,7 @@ SOFTWARE.
             It is also recommended (but not required) to completely disable your anti-virus for the duration of the guide to avoid downloaded files being flagged as dangerous.
           </p>
           <hr>
-        <h2 class="installingfnv">Generating Fresh .INI Files:</h2>
+        <a href="#generating_ini"><h2 class="installingfnv" id="generating_ini">Generating Fresh .INI Files:</h2></a>
           <p class="runningfnvdesc">
             <ul class="modfolderlist">
               <li>Run <strong>FalloutNVLauncher.exe</strong> from the root folder</li>
@@ -244,7 +244,7 @@ SOFTWARE.
               <li>Click <strong>OK</strong> and then <strong>Exit</strong></li>
             </ul>
           </p>
-                <h2 class="installingfnv">Capping FPS</h2>
+                <a href="#capping_fps"><h2 class="installingfnv" id="capping_fps">Capping FPS</h2></a>
         <div class="installcontainer">
           <button class="accordioninstall">For Users with an NVIDIA GPU</button>
             <div class="panelinstall">

--- a/core-mo2config.html
+++ b/core-mo2config.html
@@ -72,7 +72,7 @@ SOFTWARE.
         <hr class="modline">
     </div>
     <div>
-        <h2 class="installingfnv">Configuring Mod Organizer 2</h2>
+        <a href="#configuring_mo2"><h2 class="installingfnv" id="configuring_mo2">Configuring Mod Organizer 2</h2></a>
             <ul class="specialinstructions">
                 <li>Run <strong>ModOrganizer.exe</strong></li>
                 <li>From the pop-up called <strong>Choose Instance</strong>, select <strong>Portable</strong></li>
@@ -161,7 +161,7 @@ SOFTWARE.
                     </div>
             </ul>
             <hr>
-        <h2 class="installingfnv">Creating New Profiles in Mod Organizer 2</h2>
+        <a href="#creating_profiles"><h2 class="installingfnv" id="creating_profiles">Creating New Profiles in Mod Organizer 2</h2></a>
         <p class="overlaydesc">Mod Organizer 2's "Profiles" feature allows for easy switching between different mod configurations. In this step, we will setup a testing profile and a main profile. The default profile will stay completely untouched and act as a backup. The testing profile will be configured the same as the main profile for the guide, but will have all mods unchecked, allowing you to only activate certain mods for easy testing/troubleshooting. And finally, the main profile is where we will install and enable all of our mods. Profiles can be selected via the drop-down menu above the left pane</p>
                 <ul class="specialinstructions">   
                     <li>Click the <img class="mo2setting" src="./img/mo2profiles.png" alt="mo2 executables"> button on the toolbar of MO2</li>
@@ -196,7 +196,7 @@ SOFTWARE.
                             </div>
                 </ul>
                 <hr>
-        <h2 class="installingfnv">Setting up Tools in Mod Organizer 2</h2>
+        <a href="#tool_setup"><h2 class="installingfnv" id="tool_setup">Setting up Tools in Mod Organizer 2</h2></a>
             <p class="overlaydesc">In order for programs to recognize MO2's virtual file system, the programs need to be ran directly through MO2. Programs can be selected via the drop-down menu in the top right, but first we have to add them.</p>
                 <ul class="specialinstructions">
                     <li>Click the <img class="mo2setting" src="./img/mo2executabes.png" alt="mo2 executables"> button on the toolbar of MO2</li>
@@ -233,7 +233,7 @@ SOFTWARE.
                     <li>Input <strong>-FNV</strong> into the <strong>Arguments</strong> box and select <strong>Apply</strong>
                 </ul>
         <hr>
-        <h2 class="installingfnv">IMPORTANT: Mod Installation Advice in Mod Organizer 2</h2>
+        <a href="#mod_installation_advice"><h2 class="installingfnv" id="mod_installation_advice">IMPORTANT: Mod Installation Advice in Mod Organizer 2</h2></a>
                 <p class="overlaydesc">This is general advice to follow when installing mods in Mod Organizer 2:</p>
                     <ul class="specialinstructions">
                         <li>If the guide says <strong>Install normally</strong>, go to the <strong>Files</strong> tab on the Nexus page and install just the main file of the mod by using the <strong>Mod Manager Download</strong> button to download it through MO2</li>

--- a/core-optional.html
+++ b/core-optional.html
@@ -69,7 +69,7 @@ SOFTWARE.
     </div>
     <div>  
         <p class="moddesc">These are small and simple mods that I didn't think were major enough to be included in the main sections of the guide, or tools that aren't necessarily needed for just following the guide (but rather making/editing mods). They can easily be added on top of any mod setup and don't require any conflict resolution. Inversely, they can also be skipped just as easily without messing anything up:</p>
-        <h2 class="installingfnv">Optional Tools</h2>
+        <a href="#tools"><h2 class="installingfnv" id="tools">Optional Tools</h2></a>
             <p class="moddesc">Install all of the following programs to the <strong>Tools</strong> folder in your <strong>Modding Folder</strong> unless instructed otherwise:</p>
                 <h2 class="modhead"><a class="modlink" href="https://www.dotpdn.com/downloads/pdn.html" target="_blank">Paint.net</a></h2>
                     <p class="normalinstall"><strong>Install normally</strong></p>
@@ -108,7 +108,7 @@ SOFTWARE.
                                 </ul>
                         </ul>
                     <p class="moddesc"> - Adds two new features to MO2, the ability to hide plugins that have been merged and the ability to sync profile mod orders with one another</p>
-        <h2 class="installingfnv">Optional Utilities:</h2>
+        <a href="#utilities"><h2 class="installingfnv" id="utilities">Optional Utilities:</h2></a>
             <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/64888" target="_blank">GECK Extender</a></h2>
                 <p class="specialinstall"><strong>Installation instructions:</strong></p>
                     <ul class="specialinstructions">
@@ -132,7 +132,7 @@ SOFTWARE.
                         <li>Extract the contents of the archive to the <strong>Root</strong> folder</li>
                     </ul>
                 <p class="moddesc"> - Integrates Discord Rich Presence into Fallout NV</p>
-        <h2 class="installingfnv">Optional Bug Fix/QOL Mods:</h2>
+        <a href="#qol"><h2 class="installingfnv" id="qol">Optional Bug Fix/QOL Mods:</h2></a>
             <h2 class="modhead">Creating a Separator in Mod Organizer 2</h2>
                 <ul class="specialinstructions">
                     <li>Right-click in the left pane of MO2 and select <strong>All Mods -> Create Separator</strong></li>
@@ -176,7 +176,7 @@ SOFTWARE.
                         <li>Main File - <strong>Faster Pip-Boy Animation (2x)</strong></li>
                     </ul>
                 <p class="moddesc"> - Doubles the speed of the Pip-Boy opening animation</p>
-        <h2 class="installingfnv">Optional HUD Mods:</h2>
+        <a href="#hud"><h2 class="installingfnv" id="hud">Optional HUD Mods:</h2></a>
             <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/47746" target="_blank">Tutorial Killer</a></h2>
                 <p class="normalinstall"><strong>Install normally</strong></p>
                 <p class="moddesc"> - Removes tutorial pop-ups</p> 

--- a/core-tools.html
+++ b/core-tools.html
@@ -113,7 +113,7 @@ SOFTWARE.
                                 NOTE: Verifying your game files through either Steam or GOG will undo the Decompressor's effects, so you must rerun it after
             </p>
         <hr>
-        <h2 class="modhead">IMPORTANT NOTE:</h2>
+        <a href="#missing_meshes"><h2 class="modhead" id="missing_meshes">IMPORTANT NOTE:</h2></a>
             <p class="moddesc">
                 If at any point during gameplay you encounter a lot of missing mesh errors (big red triangles), do the following:
                     <ul class="specialinstructions">

--- a/core-utilities.html
+++ b/core-utilities.html
@@ -68,7 +68,7 @@ SOFTWARE.
         <hr>
     </div>
     <div>
-        <h2 class="modhead">A Note About Testing the Game</h2>
+        <a href="#note_testing"><h2 class="modhead" id="note_testing">A Note About Testing the Game</h2></a>
             <p class="moddesc">
                 After each section in every module, you should launch the game and load a save/start a new game just to make sure the game loads properly. After you finish the entire module, you should spend at least 10-15 in-game to make sure the game is running smoothly
             </p>
@@ -123,7 +123,7 @@ SOFTWARE.
             <p class="moddesc"> - Makes the game large address aware, meaning it can use 4GB of RAM instead of 2GB <br>
                                 NOTE: Verifying your game files through either Steam or GOG will undo the patch, so you must rerun it after 
             </p>
-        <h2 class="modhead">Verifying NVSE and the 4GB Patch are Working</h2>
+        <a href="#testing_nvse_4gb"><h2 class="modhead" id="testing_nvse_4gb">Verifying NVSE and the 4GB Patch are Working</h2></a>
             <ul class="specialinstructions">
                 <li>Run the game through the <strong>New Vegas</strong> option in MO2</li>
                 <li>Once the game has reached the title screen, open the console by pressing the <strong>Tilde (~)</strong> key</li>

--- a/core.html
+++ b/core.html
@@ -68,7 +68,7 @@ SOFTWARE.
         <hr>
     </div>
     <div>
-        <h2 class="corespecs">The Goal of the Core Module:</h2>
+        <a href="#goal"><h2 class="corespecs" id="goal">The Goal of the Core Module:</h2></a>
             <p class="moddesc">
                 The goal of this module is to set up all the essential modding tools for FNV as well as some essential bug fixes/quality of life improvements that give a very similar feel to vanilla, 
                 just without all the bugs and oversights. It is intended for anyone with any level of modding experience to be able follow it easily. It is all also fully modular, 
@@ -76,7 +76,7 @@ SOFTWARE.
                 and new quests/weapons that you may be accustomed to in fully modded setups are covered in the other 3 modules.
             </p>
         <hr>
-        <h2 class="corespecs">Requirements:</h2>
+        <a href="#requirements"><h2 class="corespecs" id="requirements">Requirements:</h2></a>
         <ul class="corereqlist">
             <li>
                 An English copy of <abbr title="Fallout New Vegas">FNV</abbr> with all the DLC from either 
@@ -109,7 +109,7 @@ SOFTWARE.
             <li>A <a class="modsublink" href="https://users.nexusmods.com/register" target="_blank">Nexus Mods</a> account</li>
         </ul>
         <hr>
-        <h2 class="corespecs">My System Specs:</h2>
+        <a href="#specs"><h2 class="corespecs" id="specs">My System Specs:</h2></a>
             <p class="moddesc">
                 The <strong>Core</strong> module should run much better than the vanilla game 
                     (<a class="modsublink" href="https://help.bethesda.net/app/answers/detail/a_id/16744/~/what-are-the-system-requirements-for-fallout%3A-new-vegas%3F" target="_blank">here</a> are the minimum requirements for FNV). 

--- a/gameplay.html
+++ b/gameplay.html
@@ -63,19 +63,19 @@ SOFTWARE.
         <hr>
     </div>
     <div>
-        <h2 class="corereq">Requirements:</h2>
+        <a href="#requirements"><h2 class="corereq" id="requirements">Requirements:</h2></a>
             <ul class="corereqlist">
                <li>A working installation of the <strong>Core</strong> module</li>
                <li>1 gigabyte of free disk space</li>
             </ul>
         <hr>
-        <h2 class="corereq">The Goal of the Gameplay Module:</h2>
+        <a href="#goal"><h2 class="corereq" id="goal">The Goal of the Gameplay Module:</h2></a>
             <p class="moddesc">
                 The goal of this module is to make the game harder, but not impossible, yet more rewarding. All gameplay changes are carefully picked out and tweaked by myself to make them as
                 balanced and vanilla-feeling as possible. It is designed to be played on either Normal/Hard difficulty with hardcore mode enabled so there won't be any bullet sponge enemies or major annoyances present.
             </p>
         <hr>
-        <h2 class="corespecs">My System Specs:</h2>
+        <a href="#specs"><h2 class="corespecs" id="specs">My System Specs:</h2></a>
             <ul class="corereqlist">
                 <li>The <strong>Gameplay</strong> module shouldn't run too much worse than just the <strong>Core</strong> module. My specs are just here for reference</li>
             </ul>

--- a/visuals.html
+++ b/visuals.html
@@ -60,13 +60,13 @@ SOFTWARE.
     </div>
     <div>
         <hr>
-        <h2 class="corereq">Requirements:</h2>
+        <a href="#requirements"><h2 class="corereq" id="requirements">Requirements:</h2></a>
             <ul class="corereqlist">
                <li>A working installation of the <strong>Core</strong> module</li>
                <li>1 gigabyte of free drive space (Low option), 4.5 gigabytes (Medium option), and 8.5 gigabytes (High option)</li>
             </ul>
         <hr>
-        <h2 class="corereq">The Goal of the Visuals Module:</h2>
+        <a href="#goal"><h2 class="corereq" id="goal">The Goal of the Visuals Module:</h2></a>
             <p class="moddesc">
                 The goal of this module is to improve the looks of New Vegas greatly, with different options for all ranges of PC specs. Keep in mind that Fallout New Vegas is a game
                 from 2010, and even looked bad for its time. You will never be able to make this game look like a modern AAA game, which is why this guide does not use broken, unoptimized,
@@ -75,7 +75,7 @@ SOFTWARE.
             <hr>
         <h2 class="corereq"><a class="modlink" href="https://imgur.com/a/Zlk5rRJ" target="_blank">Screenshots</a></h2>
         <hr>
-        <h2 class="corereq">Module Options:</h2>
+        <a href="#options"><h2 class="corereq" id="options">Module Options:</h2></a>
             <p class="moddesc">The <strong>Visuals</strong> module has three options to choose from depending on your system specs; low, medium, and high:</p>
             <ul class="corereqlist">
                 <li><strong>Low</strong> - No major texture overhauls, just small visual enhancements and new lighting. Very small performance impact if any</li>
@@ -83,7 +83,7 @@ SOFTWARE.
                 <li><strong>High</strong> - Texture overhauls for most common objects in the game, improved lighting/weathers, and new flora/trees/grass. Medium performance hit</li>
             </ul>
         <hr>
-        <h2 class="corereq">Recommended Specs:</h2>
+        <a href="#specs"><h2 class="corereq" id="specs">Recommended Specs:</h2></a>
             <ul class="corereqlist">
                 <li>For the <strong>Low</strong> option, just about any system that can run the <strong>Core</strong> module can handle it</li>
                 <li>For the <strong>Medium</strong> option, any semi-modern PC with a quad-core (or dual-core with hyperthreading) that has decent single-core performance, 6+ GB of RAM, and a GPU with 3GB+ of VRAM can handle it </li>

--- a/visualshigh-lod.html
+++ b/visualshigh-lod.html
@@ -70,7 +70,7 @@ SOFTWARE.
                 <li>Right-click in the left pane of MO2 and select <strong>All Mods -> Create Separator</strong></li>
                 <li>Input <strong>LOD</strong> into the pop-up and select <strong>OK</strong></li>
             </ul>
-    <h2 class="installingfnv">Installing LOD Assets:</h2>
+    <a href="#installing_lod"><h2 class="installingfnv" id="installing_lod">Installing LOD Assets:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/58562" target="_blank">FNVLODGen</a></h2>
             <p class="specialinstall"><strong>Installation instructions:</strong></p>
                 <ul class="specialinstructions">
@@ -108,7 +108,7 @@ SOFTWARE.
         <h2 class="modhead"><a class="modlink" href="https://drive.google.com/open?id=1n4eYVGJsIb-iQhMDcueHBffsW8FAMNsx" target="_blank">ETL - Terrain LOD Noise</a></h2>
             <p class="normalinstall"><strong>Install normally</strong></p>
             <p class="moddesc"> - Improves the generic LOD noise texture. Edited to lower the texture sizes to reduce shimmering. Original mod by <a class="modsublink" href="https://www.nexusmods.com/newvegas/mods/63139" target="_blank">tgspy</a></p>
-    <h2 class="installingfnv">Generating LOD:</h2>  
+    <a href="#generating_lod"><h2 class="installingfnv" id="generating_lod">Generating LOD:</h2></a>  
         <p class="moddesc">NOTE: If you installed all the mods under the <strong>Terrain and Major Objects</strong> header in the Textures/Models/Animations section, just install the following normally and ignore the instructions below: <a class="modsublink" href="https://drive.google.com/open?id=1mHhQYvqRalLv07nxWiiaGq_fPCvaYLKx" target="_blank">FNVLODGen Output</a></p>
         <p class="moddesc">The following steps are only needed if didn't install all the mods under the <strong>Terrain and Major Objects</strong> header:</p>
             <ul class="specialinstructions">

--- a/visualshigh-textures.html
+++ b/visualshigh-textures.html
@@ -79,7 +79,7 @@ SOFTWARE.
                 <li>Input <strong>Visuals</strong> into the pop-up and select <strong>OK</strong></li>
                 <li>Create another separator below that called <strong>Textures + Models + Animations</strong></li>
             </ul>
-        <h2 class="installingfnv">Clutter and Small Objects:</h2>
+        <a href="#clutter"><h2 class="installingfnv" id="clutter">Clutter and Small Objects:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/42551" target="_blank">MGs Neat Clutter Retextures</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">
@@ -119,7 +119,7 @@ SOFTWARE.
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/64686" target="_blank">High Res Vanilla Water Bottle Textures and Meshes</a></h2>
             <p class="normalinstall"><strong>Install normally</strong></p>
             <p class="moddesc"> - Vanilla-styled retexure of dirty and purified water</p>
-        <h2 class="installingfnv">Terrain and Major Objects:</h2>
+        <a href="#major_objects"><h2 class="installingfnv" id="major_objects">Terrain and Major Objects:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/43135" target="_blank">NMC's Texture Pack</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">
@@ -197,7 +197,7 @@ SOFTWARE.
         <h2 class="modhead"><a class="modlink" href="https://github.com/VivaNewVegas/Viva-New-Vegas-Patch-Emporium/blob/master/Semi-Transparent%20Door%20Glass%20ESP%20Replacer.7z" target="_blank">Semi-Transparent Door Glass ESP Replacer</a></h2>
             <p class="normalinstall"><strong>Install normally</strong></p>
             <p class="moddesc"> - Removes edits to cells that would make the entire interior invisible, reverts wild edits to the water levels of certain cells, and forwards YUPs fixes</p>
-        <h2 class="installingfnv">Weapons/Armor:</h2> 
+        <a href="#weapons_armor"><h2 class="installingfnv" id="weapons_armor">Weapons/Armor:</h2></a> 
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/61390" target="_blank">ADAM Reborn</a></h2>
             <p class="specialinstall"><strong>Installation instructions:</strong></p>
                 <ul class="specialinstructions">
@@ -320,7 +320,7 @@ SOFTWARE.
                     <li>Optional File - <strong>Normalmap fix (no ugly shiny)</strong></li>
                 </ul>
             <p class="moddesc"> - HD retexture of the throwing spear, throwing knives, and throwing hatchet</p>
-        <h2 class="installingfnv">NPCs/Creatures:</h2>
+        <a href="#npc_creatures"><h2 class="installingfnv" id="npc_creatures">NPCs/Creatures:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/64862" target="_blank">Character Expansions Revised</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">
@@ -375,7 +375,7 @@ SOFTWARE.
                         <div id="caption4"></div>
                     </div>
             <p class="moddesc"> - Retexture with custom glow maps of Ed-E and all his variants </p>
-        <h2 class="installingfnv">FX:</h2>
+        <a href="#fx"><h2 class="installingfnv" id="fx">FX:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/62989" target="_blank">EXE - Effect Textures Enhanced</a></h2> 
             <p class="specialinstall"><strong>Hide the following:</strong></p>
                 <ul class="specialinstructions">
@@ -399,7 +399,7 @@ SOFTWARE.
                         </ul>
                 </ul>
             <p class="moddesc"> - Improves both static and generated blood and blood effects</p>
-    <h2 class="installingfnv">Animations:</h2>
+    <a href="#animations"><h2 class="installingfnv" id="animations">Animations:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/70158" target="_blank">Anniversary Animation Pack</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">

--- a/visualslow-lod.html
+++ b/visualslow-lod.html
@@ -70,7 +70,7 @@ SOFTWARE.
                 <li>Right-click in the left pane of MO2 and select <strong>All Mods -> Create Separator</strong></li>
                 <li>Input <strong>LOD</strong> into the pop-up and select <strong>OK</strong></li>
             </ul>
-    <h2 class="installingfnv">Installing LOD Assets:</h2>
+    <a href="#installing_lod"><h2 class="installingfnv" id="installing_lod">Installing LOD Assets:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/58562" target="_blank">FNVLODGen</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">
@@ -86,7 +86,7 @@ SOFTWARE.
         <h2 class="modhead"><a class="modlink" href="https://drive.google.com/open?id=1n4eYVGJsIb-iQhMDcueHBffsW8FAMNsx" target="_blank">ETL - Terrain LOD Noise</a></h2>
             <p class="normalinstall"><strong>Install normally</strong></p>
             <p class="moddesc"> - Improves the generic LOD noise texture. Edited to lower the texture sizes to reduce shimmering. Original mod by <a class="modsublink" href="https://www.nexusmods.com/newvegas/mods/63139" target="_blank">tgspy</a></p>
-    <h2 class="installingfnv">Generating LOD:</h2>   
+    <a href="#generating_lod"><h2 class="installingfnv" id="generating_lod">Generating LOD:</h2></a>    
         <p class="moddesc">NOTE: If you did not install your own large-scale texture mods not in the guide, such as NMCs Texture Pack, just install the following normally and ignore the instructions below: <a class="modsublink" href="https://drive.google.com/open?id=1_IeD9QpSal8xSsygLuUW6vh2OHnJ7skG" target="_blank">FNVLODGen Output</a></p>
         <p class="moddesc">The following steps are only needed if you installed your own large-scale texture mods not in the guide, such as NMCs texture pack:</p>
             <ul class="specialinstructions">

--- a/visualslow-textures.html
+++ b/visualslow-textures.html
@@ -79,14 +79,14 @@ SOFTWARE.
                 <li>Input <strong>Visuals</strong> into the pop-up and select <strong>OK</strong></li>
                 <li>Create another separator below that called <strong>Textures + Models + Animations</strong></li>
             </ul>
-    <h2 class="installingfnv">Textures:</h2>
+    <a href="#textures"><h2 class="installingfnv" id="textures">Textures:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/63742" target="_blank">Semi-Transparent Door Glass</a></h2>
             <p class="specialinstall"><strong>Install Normally:</strong></p>
             <p class="moddesc"> - Makes glass on appropriate doors transparent</p>
         <h2 class="modhead"><a class="modlink" href="https://github.com/VivaNewVegas/Viva-New-Vegas-Patch-Emporium/blob/master/Semi-Transparent%20Door%20Glass%20ESP%20Replacer.7z" target="_blank">Semi-Transparent Door Glass ESP Replacer</a></h2>
             <p class="normalinstall"><strong>Install normally</strong></p>
             <p class="moddesc"> - Removes edits to cells that would make the entire interior invisible, reverts wild edits to the water levels of certain cells, and forwards YUPs fixes</p>
-    <h2 class="installingfnv">NPCs:</h2>
+    <a href="#npcs"><h2 class="installingfnv" id="npcs">NPCs:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/64862" target="_blank">Character Expansions Revised</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">
@@ -94,7 +94,7 @@ SOFTWARE.
                     <li>Optional File - <strong>Character Expansions Revised - YUP</strong></li>
                 </ul>
             <p class="moddesc"> - Visual overhaul of characters’ faces that stays true to vanilla aesthetics</p>
-    <h2 class="installingfnv">Animations:</h2>
+    <a href="#animations"><h2 class="installingfnv" id="animations">Animations:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/70158" target="_blank">Anniversary Animation Pack</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">

--- a/visualsmedium-lod.html
+++ b/visualsmedium-lod.html
@@ -70,7 +70,7 @@ SOFTWARE.
                 <li>Right-click in the left pane of MO2 and select <strong>All Mods -> Create Separator</strong></li>
                 <li>Input <strong>LOD</strong> into the pop-up and select <strong>OK</strong></li>
             </ul>
-    <h2 class="installingfnv">Installing LOD Assets:</h2>
+    <a href="#installing_lod"><h2 class="installingfnv" id="installing_lod">Installing LOD Assets:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/58562" target="_blank">FNVLODGen</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">
@@ -92,7 +92,7 @@ SOFTWARE.
         <h2 class="modhead"><a class="modlink" href="https://drive.google.com/open?id=1n4eYVGJsIb-iQhMDcueHBffsW8FAMNsx" target="_blank">ETL - Terrain LOD Noise</a></h2>
             <p class="normalinstall"><strong>Install normally</strong></p>
             <p class="moddesc"> - Improves the generic LOD noise texture. Edited to lower the texture sizes to reduce shimmering. Original mod by <a class="modsublink" href="https://www.nexusmods.com/newvegas/mods/63139" target="_blank">tgspy</a></p>
-    <h2 class="installingfnv">Generating LOD:</h2>        
+    <a href="#generating_lod"><h2 class="installingfnv" id="generating_lod">Generating LOD:</h2></a>       
         <p class="moddesc">NOTE: If you installed all the mods under the <strong>Terrain and Major Objects</strong> header in the Textures/Models/Animations section, just install the following normally and ignore the instructions below: <a class="modsublink" href="https://drive.google.com/open?id=1z5G4SWIiryaAzI0xwUzamsB9-ezAoc-L" target="_blank">FNVLODGen Output</a></p>
         <p class="moddesc">The following steps are only needed if didn't install all the mods under the <strong>Terrain and Major Objects</strong> header:</p>
             <ul class="specialinstructions">

--- a/visualsmedium-textures.html
+++ b/visualsmedium-textures.html
@@ -79,14 +79,14 @@ SOFTWARE.
                 <li>Input <strong>Visuals</strong> into the pop-up and select <strong>OK</strong></li>
                 <li>Create another separator below that called <strong>Textures + Models + Animations</strong></li>
             </ul>
-    <h2 class="installingfnv">Clutter and Small Objects:</h2>
+    <a href="#clutter"><h2 class="installingfnv" id="clutter">Clutter and Small Objects:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/42551" target="_blank">MGs Neat Clutter Retextures</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">
                     <li>Main File - <strong>MGs NCR Pack 7</strong></li>
                 </ul>
             <p class="moddesc"> - Texture pack that focuses on clutter items that other big packs do not cover</p>
-    <h2 class="installingfnv">Terrain and Major Objects:</h2>
+    <a href="#major_objects"><h2 class="installingfnv" id="major_objects">Terrain and Major Objects:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/43135" target="_blank">NMC's Texture Pack</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">
@@ -133,7 +133,7 @@ SOFTWARE.
         <h2 class="modhead"><a class="modlink" href="https://github.com/VivaNewVegas/Viva-New-Vegas-Patch-Emporium/blob/master/Semi-Transparent%20Door%20Glass%20ESP%20Replacer.7z" target="_blank">Semi-Transparent Door Glass ESP Replacer</a></h2>
             <p class="normalinstall"><strong>Install normally</strong></p>
             <p class="moddesc"> - Removes edits to cells that would make the entire interior invisible, reverts wild edits to the water levels of certain cells, and forwards YUPs fixes</p>
-    <h2 class="installingfnv">Weapons/Armor:</h2> 
+    <a href="#weapons_armor"><h2 class="installingfnv" id="weapons_armor">Weapons/Armor:</h2></a> 
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/fallout3/mods/22065" target=_blank>4k Realistic Pip-Boy Retexture</a></h2> 
             <p class="specialinstall"><strong>Files to install normally:</strong></p> 
                 <ul class="specialinstructions">
@@ -158,7 +158,7 @@ SOFTWARE.
                     <li>Optional File - <strong>WTH - WRP Patch</strong></li>
                 </ul>
             <p class="moddesc"> - Weapon retexture similar to Weapon Retexture Project, but with a bigger focus on lore-friendliness</p>
-    <h2 class="installingfnv">NPCs:</h2>
+    <<a href="#npcs"><h2 class="installingfnv" id="npcs">NPCs:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/64862" target="_blank">Character Expansions Revised</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">
@@ -166,7 +166,7 @@ SOFTWARE.
                     <li>Optional File - <strong>Character Expansions Revised - YUP</strong></li>
                 </ul>
             <p class="moddesc"> - Visual overhaul of characters’ faces that stays true to vanilla aesthetics</p>
-    <h2 class="installingfnv">Animations:</h2>
+    <a href="#animations"><h2 class="installingfnv" id="animations">Animations:</h2></a>
         <h2 class="modhead"><a class="modlink" href="https://www.nexusmods.com/newvegas/mods/70158" target="_blank">Anniversary Animation Pack</a></h2>
             <p class="specialinstall"><strong>Files to install normally:</strong></p>
                 <ul class="specialinstructions">


### PR DESCRIPTION
Added internal links to appropriate headers. This lets you link to a specific part of the page in the guide.
For example, https://vivanewvegas.github.io/core-mo2config.html#mod_installation_advice will take you to the Mod Installation Advice section of the page.