### PR TITLE
Remove links of listed mods

### DIFF
--- a/intro.html
+++ b/intro.html
@@ -150,57 +150,38 @@ SOFTWARE.
                 <ul class="standard_ul">
                     <li>
                         <b>Utilities:</b>
-                        <a href="https://github.com/xNVSE/NVSE/releases" target="_blank">xNVSE</a>, <a href="https://www.nexusmods.com/newvegas/mods/62552" target="_blank">4GB Patcher</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/69779" target="_blank">New Vegas Heap Replacer</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/58277" target="_blank">JIP LN NVSE Plugin</a>, <a href="https://www.nexusmods.com/newvegas/mods/66927" target="_blank">JohnnyGuitar NVSE</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/53635" target="_blank">New Vegas Anti-Crash</a>, <a href="https://www.nexusmods.com/newvegas/mods/66537" target="_blank">New Vegas Tick Fix</a>,
-                        <a href="https://github.com/VivaNewVegas/Viva-New-Vegas-Patch-Emporium/blob/main/NVTF%20Custom%20INI.7z" target="_blank">New Vegas Tick Fix Custom INI</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/68714" target="_blank">Mod Limit Fix</a>, <a href="https://www.nexusmods.com/skyrim/mods/40706" target="_blank">OneTweak</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/65906" target="_blank">Console Paste Support</a>
+                        xNVSE, 4GB Patcher, New Vegas Heap Replacer, JIP LN NVSE Plugin, JohnnyGuitar NVSE, New Vegas Anti-Crash,
+                        New Vegas Tick Fix, New Vegas Tick Fix Custom INI, Mod Limit Fix, OneTweak, Console Paste Support
                     </li>
 
                     <li>
                         <b>Bug Fixes/Quality of Life Improvements:</b>
-                        <a href="https://www.nexusmods.com/newvegas/mods/51664" target="_blank">Yukichigai Unofficial Patch</a>, <a href="https://www.nexusmods.com/newvegas/mods/71239" target="_blank">Unofficial Patch NVSE Plus</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/65052" target="_blank">Weapon Mesh Improvement Mod</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/66347" target="_blank">lStewieAl's Tweaks</a>, <a href="https://github.com/VivaNewVegas/Viva-New-Vegas-Patch-Emporium/blob/main/lStewieAl's%20Tweaks%20Custom%20INI.7z" target="_blank">lStewieAl's Tweaks Custom INI</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/67761" target="_blank">Faster Pip-Boy Animation</a>, <a href="https://www.nexusmods.com/newvegas/mods/69038" target="_blank">No Muzzle Flash Lights</a>
+                        Yukichigai Unofficial Patch, Unofficial Patch NVSE Plus, Weapon Mesh Improvement Mod, lStewieAl's Tweaks,
+                        lStewieAl's Tweaks Custom INI, Faster Pip-Boy Animation, No Muzzle Flash Lights
                     </li>
 
                     <li>
                         <b>User Interface Mods:</b>
-                        <a href="https://www.nexusmods.com/newvegas/mods/57174" target="_blank">User Interface Organizer</a>, <a href="https://www.nexusmods.com/newvegas/mods/42507" target="_blank">The Mod Configuration Menu</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/59638" target="_blank">JIP Improved Recipe Menu</a>, <a href="https://www.nexusmods.com/newvegas/mods/62779" target="_blank">Simple DLC Delay</a>,
-                        <a href="https://www.moddb.com/mods/vanilla-ui-plus/downloads/vanilla-ui-plus-nv" target="_blank">Vanilla UI Plus</a>, <a href="https://www.nexusmods.com/newvegas/mods/70001" target="_blank">Vanilla HUD Cleaned</a>
+                        User Interface Organizer, The Mod Configuration Menu, JIP Improved Recipe Menu, Simple DLC Delay, 
+                        Vanilla UI Plus, Vanilla HUD Cleaned
                     </li>
 
                     <li>
                         <b>Visual Mods:</b>
-                        <a href="https://www.nexusmods.com/newvegas/mods/71556">New Vegas Redesigned 2 Revised</a>, <a href="https://www.nexusmods.com/newvegas/mods/70158" target="_blank">Anniversary Animation Pack</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/64335" target="_blank">B42 Weapon Inertia</a>, <a href="https://www.nexusmods.com/newvegas/mods/68776" target="_blank">NV Compatibility Skeleton</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/46451" target="_blank">Improved LOD Noise Texture</a>, <a href="https://drive.google.com/file/d/1lznQ6JB8093BUrLsXR5jKK_x-INB7fX2/view" target="_blank">Vanilla LOD</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/71390" target="_blank">Simple Interior Lighting Overhaul</a>, <a href="https://www.nexusmods.com/newvegas/mods/71404" target="_blank">Altitude</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/69226" target="_blank">A Little More Lamplight</a>
+                        New Vegas Redesigned 2 Revised, Anniversary Animation Pack, B42 Weapon Inertia, NV Compatibility Skeleton, 
+                        Improved LOD Noise Texture, Vanilla LOD, Simple Interior Lighting Overhaul, Altitude, A Little More Lamplight
                     </li>
 
                     <li>
                         <b>Gameplay Mods:</b>
-                        <a href="https://www.nexusmods.com/newvegas/mods/62180" target="_blank">Follower Tweaks</a>,
-                         <a href="https://www.nexusmods.com/newvegas/mods/68153" target="_blank">GRA Unique Weapons Relocated</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/68084" target="_blank">Just Loot Menu</a>, <a href="https://www.nexusmods.com/newvegas/mods/66676" target="_blank">Just Dynamic Crosshair</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/66667" target="_blank">Just Hit Marker</a>, <a href="https://www.nexusmods.com/newvegas/mods/68485" target="_blank">Marathoner</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/62153" target="_blank">Real Recoil</a>, <a href="https://github.com/VivaNewVegas/Viva-New-Vegas-Patch-Emporium/blob/main/Real%20Recoil%20Custom%20INI.7z" target="_blank">Real Recoil Custom INI</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/56625" target="_blank">Uncut Wasteland</a>
+                        Follower Tweaks, GRA Unique Weapons Relocated, Just Loot Menu, Just Dynamic Crosshair, Just Hit Marker, Marathoner,
+                        Real Recoil, Real Recoil Custom INI, Uncut Wasteland
                     </li>
 
                     <li>
                         <b>Overhaul Mods:</b>
-                        <a href="https://www.nexusmods.com/newvegas/mods/71512" target="_blank">Complex Vendors</a>, <a href="https://www.nexusmods.com/newvegas/mods/61592" target="_blank">JSawyer Ultimate Edition</a>,
-                        <a href="https://github.com/VivaNewVegas/Viva-New-Vegas-Patch-Emporium/blob/main/JSawyer%20Ultimate%20Edition%20Custom%20INI.7z" target="_blank">JSawyer Ultimate Custom INI</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/62899" target="_blank">Economy Overhaul</a>, <a href="https://www.nexusmods.com/newvegas/mods/67655" target="_blank">Unfound Loot</a>,
-                        <a href="https://github.com/VivaNewVegas/Viva-New-Vegas-Patch-Emporium/blob/main/Unfound%20Loot%20Custom%20INI.7z" target="_blank">Unfound Loot Custom INI</a>, <a href="https://www.nexusmods.com/newvegas/mods/71490" target="_blank">Follower Formula Redone</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/70973" target="_blank">Better Character Creation</a>, <a href="https://www.nexusmods.com/newvegas/mods/71101" target="_blank">Better Ghouls</a>,
-                        <a href="https://www.nexusmods.com/newvegas/mods/64623" target="_blank">The Living Desert</a>, <a href="https://www.nexusmods.com/newvegas/mods/71536" target="_blank">Mobile Truck Base Remastered</a>
+                        Complex Vendors, JSawyer Ultimate Edition, JSawyer Ultimate Custom INI, Economy Overhaul, Unfound Loot, Unfound Loot Custom INI,
+                        Follower Formula Redone, Better Character Creation, Better Ghouls, The Living Desert, Mobile Truck Base Remastered
                     </li>
                 </ul>
                 <br>


### PR DESCRIPTION
Too many users downloading mods like that, coming from ugly formatted mod guides. To be replaced with a html table but requires some css rework.