### PR TITLE
Add Texture Size Large to FalloutCustom

### DIFF
--- a/mo2.html
+++ b/mo2.html
@@ -201,6 +201,9 @@ SOFTWARE.
                                     [BackgroundLoad]<br>
                                     bSelectivePurgeUnusedOnFastTravel=1<br> <br>
 
+                                    [Display]<br>
+                                    iTexMipMapSkip=0<br><br>
+
                                     [Controls]<br>
                                     fForegroundMouseAccelBase=0<br>
                                     fForegroundMouseAccelTop=0<br>

--- a/mo2.html
+++ b/mo2.html
@@ -202,6 +202,7 @@ SOFTWARE.
                                     bSelectivePurgeUnusedOnFastTravel=1<br> <br>
 
                                     [Display]<br>
+                                    bFull Screen=1<br>
                                     iTexMipMapSkip=0<br><br>
 
                                     [Controls]<br>

--- a/utilities.html
+++ b/utilities.html
@@ -210,10 +210,10 @@ SOFTWARE.
                             </ul>
                             <img width="600px" src="./img/onetweak install.png" alt="">
                         <li>Once the files have been extracted, click the <img src="./img/mo2 ini.png" alt="mo2 ini button"> button at the top of MO2 and select <strong>INI Editor</strong></li>
-                        <li>Select the <strong>FalloutCustom.ini</strong> tab and paste in the following:</li>
+                        <li>Select the <strong>FalloutCustom.ini</strong> tab</li>
+                        <li>Change the following option:</li>
                             <p class="smalllist">
-                                [Display] <br>
-                                bFull Screen=0
+                              set <strong>bFull Screen</strong> to <strong>0</strong>
                             </p>
                     </ol>
                 <p class="subparagraph"> - Enables borderless windowed mode for safe alt-tabbing</p>


### PR DESCRIPTION
Players sometimes select a different texture size, thinking they get better performance. However this 'breaks' some modded textures, showing / rendering them as glitched textures.