### PR TITLE
Remove optional JSUE GRA Merged

### DIFF
--- a/overhauls.html
+++ b/overhauls.html
@@ -65,7 +65,6 @@
             <h2 class="install">Installation instructions:</h2>
                 <ul class="standard_ul">
                     <li><b>Main File - JSawyer Ultimate Edition</b></li>
-                    <li><b>Optional File - JSawyer Ultimate Edition - GRA Merged</b> (When prompted, select the name that matches the file on nexus)</li>
                     <li><b>Optional File - JSawyer Ultimate Edition - Push's Tweaks</b> (When prompted, select the name that matches the file on nexus)</li>
                 </ul>
             <p class="subparagraph">An updated and fixed version of the gameplay re-balance mod made by the lead director of the game, Josh Sawyer.</p>

--- a/overhauls.html
+++ b/overhauls.html
@@ -45,6 +45,7 @@
 
     <div class="sidenavright">
         <a href="./overhauls.html#jsawyer"><span style="font-size:.8vw;">JSawyer</span></a>
+        <a href="./overhauls.html#mojavearsenal"><span style="font-size:.8vw;">Mojave Arsenal</span></a>
         <a href="./overhauls.html#famine"><span style="font-size:.8vw;">Famine</span></a>
         <a href="./overhauls.html#food_healing"><span style="font-size:.8vw;">Food Effect Tweaks</span></a>
         <a href="./overhauls.html#player_priority"><span style="font-size:.8vw;">Player Combat Priority</span></a>
@@ -69,6 +70,12 @@
                 </ul>
             <p class="subparagraph">An updated and fixed version of the gameplay re-balance mod made by the lead director of the game, Josh Sawyer.</p>
             <blockquote class="blockquote">The INI for this mod contains many configurable features, such as an adjustable level cap and carry capacity formula. You should look through the INI and see if there are any features you would like to change. For example, you can set <strong>fCarryWeightBase</strong> to <strong>150</strong> if you want the vanilla carry weight formula back.</blockquote>
+        <a class="internallink" href="#mojavearsenal"><h2 class="smallheader" id="mojavearsenal"><a href="https://www.nexusmods.com/newvegas/mods/62941" target="_blank">Mojave Arsenal</a></h2></a>
+            <h2 class="install">Installation instructions:</h2>
+                <ul class="standard_ul">
+                    <li><b>Main File - Mojave Arsenal</b></li>
+                </ul>
+            <p class="subparagraph">Adds ammo variants, reloading parts, and weapon mods as loot; provides comprehensive options for configuring and integrating Gun Runners' Arsenal; fixes item naming conventions; and improves recipes. </p>
         <a class="internallink" href="#famine"><h2 class="smallheader" id="famine"><a href="https://www.nexusmods.com/newvegas/mods/74985" target="_blank">Famine - A Loot Rarity Mod</a></h2></a>
             <h2 class="install">Installation instructions:</h2>
                 <ul class="standard_ul">


### PR DESCRIPTION
No longer recommended by PushTheWinButton.

However, it does similiar things like Supplemental Ammo Crafting so either a patch is needed or Supplemental Ammo Crafting needs to be removed / replaced by Mojave Arsenal.