### PR TITLE
Vertically Centered the Navigation bar links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -256,7 +256,7 @@ img {
   color: rgb(255, 255, 255);
 }
 
-.titlecontainer .guideLinks {
+.titlecontainer .{
   display: flex;
   margin-left: auto;
 }
@@ -264,7 +264,6 @@ img {
 .titlecontainer .guideLinks a {
   color: rgb(220, 220, 220);
   font-size: 1.2em;
-  margin-top: 0.75em;
 }
 
 .titlecontainer img {


### PR DESCRIPTION
Doing only the thing the title says. I don't know if the not vertically centered layout was intentional, but I've been returning to the guide from time to time and I kept thinking how annoying this was. I can't donate yet so I thought I would at least try to benefit you in some way:)